### PR TITLE
[FEAT] 자동완성 기능 초기 구현 (#36)

### DIFF
--- a/PillTip/BE/test_oauth2/build.gradle
+++ b/PillTip/BE/test_oauth2/build.gradle
@@ -28,13 +28,21 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'org.springframework.boot:spring-boot-starter-data-elasticsearch'
+	implementation 'co.elastic.clients:elasticsearch-java:8.11.1'
+	implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.0'
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Config/ElasticsearchConfig.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Config/ElasticsearchConfig.java
@@ -1,0 +1,91 @@
+package com.oauth2.AutoComplete.Config;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+
+@Configuration
+public class ElasticsearchConfig extends ElasticsearchConfiguration {
+
+    @Value("${elastic.id}")
+    private String id;
+
+    @Value("${elastic.pw}")
+    private String pw;
+
+    @Value("${elastic.ip}")
+    private String ip;
+
+    @Value("${elastic.port}")
+    private String port;
+
+
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+            .connectedTo(ip+":"+port)
+            .withBasicAuth(id, pw)
+            .build();
+    }
+
+    @Bean
+    public ElasticsearchClient elasticsearchClient() {
+        BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+        credentialsProvider.setCredentials(AuthScope.ANY,
+                new UsernamePasswordCredentials(id, pw)); //아이디 비번
+
+        RestClientBuilder builder = RestClient.builder(
+                        new org.apache.http.HttpHost(ip, Integer.parseInt(port)))  // 도커 컨테이너의 주소
+                .setHttpClientConfigCallback(httpClientBuilder ->
+                        httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider)
+                );
+
+        RestClient restClient = builder.build();
+
+        RestClientTransport transport = new RestClientTransport(
+                restClient, new JacksonJsonpMapper());
+
+        return new ElasticsearchClient(transport);
+    }
+    
+
+    /**
+     * 인덱스 생성 및 자소 분석기 설정은 별도 스크립트나 API 호출로 구현
+     * 
+     * PUT drug_autocomplete
+     * {
+     *   "settings": {
+     *     "analysis": {
+     *       "analyzer": {
+     *         "edgeNgram_analyzer": {
+     *           "type": "custom",
+     *           "tokenizer": "edgeNgram_tokenizer"
+     *         }
+     *       },
+     *       "tokenizer": {
+     *         "edgeNgram_tokenizer": {
+     *           "type": "edgeNgram_tokenizer"
+     *         }
+     *       }
+     *     }
+     *   },
+     *   "mappings": {
+     *     "properties": {
+     *       "drugId": { "type": "keyword" },
+     *       "productName": { "type": "text", "analyzer": "edgeNgram_analyzer" },
+     *       "manufacturer": { "type": "text", "analyzer": "edgeNgram_analyzer" }
+     *     }
+     *   }
+     * }
+     */
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Controller/AutocompleteController.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Controller/AutocompleteController.java
@@ -1,0 +1,55 @@
+package com.oauth2.AutoComplete.Controller;
+
+import com.oauth2.AutoComplete.Dto.AutocompleteResult;
+import com.oauth2.AutoComplete.Service.AutocompleteService;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/autocomplete")
+public class AutocompleteController {
+
+    private final AutocompleteService autocompleteService;
+
+    @Value("${elastic.drug.drug}")
+    private String drug;
+
+    @Value("${elastic.drug.ingredient}")
+    private String ingredient;
+
+    @Value("${elastic.drug.manufacturer}")
+    private String manufacturer;
+
+    private int pageSize = 20;
+
+    public AutocompleteController(AutocompleteService autocompleteService) {
+        this.autocompleteService = autocompleteService;
+    }
+
+    @GetMapping("/drugs")
+    public List<AutocompleteResult> getDrugSearch(
+            @RequestParam String input,
+            @RequestParam(defaultValue = "0") int page) throws IOException {
+        return autocompleteService.getDrugSearch(input, drug, pageSize, page);
+    }
+
+    @GetMapping("/manufacturer")
+    public List<AutocompleteResult> getManufacturerSearch(
+            @RequestParam String input,
+            @RequestParam(defaultValue = "0") int page) throws IOException {
+        return autocompleteService.getDrugSearch(input, manufacturer, pageSize, page);
+    }
+
+    @GetMapping("/ingredient")
+    public List<AutocompleteResult> getIngredientSearch(
+            @RequestParam String input,
+            @RequestParam(defaultValue = "0") int page) throws IOException {
+        return autocompleteService.getDrugSearch(input, ingredient, pageSize, page);
+    }
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Dto/AutocompleteResult.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Dto/AutocompleteResult.java
@@ -1,0 +1,12 @@
+package com.oauth2.AutoComplete.Dto;
+
+
+/**
+ * @param id            약의 상세 페이지로 이동할 수 있는 ID
+ * @param drugName      추천 텍스트
+ * @param manufacturer  약의 제조사
+ * @param imageUrl      약 이미지 URL
+ */
+
+public record AutocompleteResult(Long id, String drugName, String manufacturer, String imageUrl) {
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Dto/DrugDTO.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Dto/DrugDTO.java
@@ -1,0 +1,6 @@
+package com.oauth2.AutoComplete.Dto;
+
+
+public record DrugDTO(Long id, String drugName, String manufacturer, String imageUrl) {
+
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Service/AutocompleteService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Service/AutocompleteService.java
@@ -1,0 +1,240 @@
+package com.oauth2.AutoComplete.Service;
+
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch._types.analysis.*;
+import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.clients.elasticsearch.core.IndexRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
+import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
+import co.elastic.clients.elasticsearch.indices.IndexSettings;
+import co.elastic.clients.elasticsearch.indices.IndexSettingsAnalysis;
+import com.oauth2.AutoComplete.Dto.AutocompleteResult;
+import com.oauth2.AutoComplete.Dto.DrugDTO;
+import com.oauth2.Drug.Domain.Drug;
+import com.oauth2.Drug.Repository.DrugRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+@Service
+public class AutocompleteService {
+
+    private final ElasticsearchClient elasticsearchClient;
+    private final RedisService redisService;
+    private final DrugRepository drugRepository;
+
+    @Value("${elastic.index}")
+    private String index;
+
+    @Value("${elastic.nGramAnalyzer}")
+    private String autoNGramAnalyzer;
+
+    @Value("${elastic.edgeNGramAnalyzer}")
+    private String autoEdgeNGramAnalyzer;
+    @Value("${elastic.nGram}")
+    private String nGram;
+    @Value("${elastic.edgeNGram}")
+    private String edgeNGram;
+
+    @Value("${elastic.drug.id}")
+    private String id;
+
+    @Value("${elastic.drug.drug}")
+    private String drugName;
+    @Value("${elastic.drug.manufacturer}")
+    private String manufacturer;
+
+    @Value("${elastic.drug.ingredient}")
+    private String ingredient;
+
+
+    public AutocompleteService(ElasticsearchClient elasticsearchClient, RedisService redisService, DrugRepository drugRepository) {
+        this.elasticsearchClient = elasticsearchClient;
+        this.redisService = redisService;
+        this.drugRepository = drugRepository;
+    }
+
+    // 인덱스를 기준으로 analyzer,tokenizer,indexsetting 등을 가짐
+    // 즉, 성분, 제조사 등의 DTO가 다르다면, 다른 타입이 매핑되어야 하므로, 새 인덱스를 생성해야할듯
+    // 성분, 제조사는 약과 같이 이미지가 없으므로, 다른 dto를 사용할 가능성이 높음 / 혹은 프론트 단에서 무시
+    // 이미지는 어떻게 넣을것?
+    //- firebase에 약품 id와 매핑해서 저장 후, 약의 대한 정보를 주면 firebase에서 받아오기
+    //- 이미지 url도 DB에 저장해서 사용하기
+
+    @PostConstruct //완벽해지면 최초실행시에만 활성화하고 그 뒤로는 꺼두기
+    public void createIndex() throws IOException {
+        // 먼저 기존 인덱스 삭제 (개발 중일 경우만)
+        if (elasticsearchClient.indices().exists(e -> e.index(index)).value()) {
+            elasticsearchClient.indices().delete(d -> d.index(index));
+        }
+
+        NGramTokenizer nGramTokenizer = new NGramTokenizer.Builder()
+                // 단어를 최소 1글자에서 4글자 까지 나눔
+                // ex) 에어신신파스 -> 에, 어, 신, 신 ..., 에어, 어신 ..., 에어신 어신파 ..., 에어신신 ..., 신신파스
+                .minGram(1)
+                .maxGram(4)
+                .tokenChars(TokenChar.Letter, TokenChar.Digit, TokenChar.Symbol,TokenChar.Punctuation,TokenChar.Whitespace)
+                .build();
+
+        TokenizerDefinition tokenizerNGram = new TokenizerDefinition.Builder()
+                .ngram(nGramTokenizer)
+                .build();
+
+        CustomAnalyzer customNGramAnalyzer = new CustomAnalyzer.Builder()
+                .tokenizer(nGram)
+                .filter("lowercase")
+                .build();
+
+        Analyzer nGramAnalyzer = new Analyzer.Builder()
+                .custom(customNGramAnalyzer)
+                .build();
+
+        EdgeNGramTokenizer edgeNGramTokenizer = new EdgeNGramTokenizer.Builder()
+                // 단어를 최소 1글자에서 4글자 까지 나눔
+                // ex) 에어신신파스 -> 에, 어, 신, 신 ..., 에어, 어신 ..., 에어신 어신파 ..., 에어신신 ..., 신신파스
+                .minGram(1)
+                .maxGram(20)
+                .tokenChars(TokenChar.Letter, TokenChar.Digit, TokenChar.Symbol,TokenChar.Punctuation,TokenChar.Whitespace)
+                .build();
+
+        TokenizerDefinition tokenizerEdgeNGram = new TokenizerDefinition.Builder()
+                .edgeNgram(edgeNGramTokenizer)
+                .build();
+
+        CustomAnalyzer customEdgeNGramAnalyzer = new CustomAnalyzer.Builder()
+                .tokenizer(edgeNGram)
+                .filter("lowercase")
+                .build();
+
+        Analyzer edgeNGramAnalyzer = new Analyzer.Builder()
+                .custom(customEdgeNGramAnalyzer)
+                .build();
+
+
+        // 분석기 설정
+        IndexSettingsAnalysis analysis = new IndexSettingsAnalysis.Builder()
+                .analyzer(autoNGramAnalyzer, nGramAnalyzer)
+                .analyzer(autoEdgeNGramAnalyzer, edgeNGramAnalyzer)
+                .tokenizer(nGram, b -> b.definition(tokenizerNGram))
+                .tokenizer(edgeNGram, b->b.definition(tokenizerEdgeNGram))
+                .build();
+
+        IndexSettings settings = new IndexSettings.Builder()
+                .maxNgramDiff(5)
+                .analysis(analysis)
+                .build();
+
+        // Mapping 설정
+        TypeMapping mapping = new TypeMapping.Builder()
+                .properties(id, p -> p
+                        .keyword(k -> k.index(false))
+                )
+                .properties(drugName, p -> p
+                        .text(t -> t.fields("edge", f->f.text(edge -> edge.analyzer(autoEdgeNGramAnalyzer)))
+                                .fields("gram", f->f.text(gram->gram.analyzer(autoNGramAnalyzer))))
+                )
+                .properties(manufacturer, p -> p
+                        .text(t -> t.fields("edge", f->f.text(edge -> edge.analyzer(autoEdgeNGramAnalyzer)))
+                                .fields("gram", f->f.text(gram->gram.analyzer(autoNGramAnalyzer))))
+                )
+                .build();
+
+        // 인덱스 생성 요청 빌드
+        CreateIndexRequest request = new CreateIndexRequest.Builder()
+                .index(index)
+                .settings(settings)
+                .mappings(mapping)
+                .build();
+
+        // 인덱스 생성
+        elasticsearchClient.indices().create(request);
+        syncDrugsToElasticsearch();
+    }
+
+    public void syncDrugsToElasticsearch() throws IOException {
+        List<Drug> drugs = drugRepository.findAll();
+        for (int i=0; i<1000; i++){
+            Drug drug = drugs.get(i);
+        //for (Drug drug : drugs) {
+            DrugDTO dto = new DrugDTO(
+                    drug.getId(),
+                    drug.getName(),
+                    drug.getManufacturer(),
+                    null // imageUrl은 필요시 Redis 또는 별도 처리
+            );
+
+            IndexRequest<DrugDTO> indexRequest = new IndexRequest.Builder<DrugDTO>()
+                    .index(index)
+                    .id(String.valueOf(dto.id()))
+                    .document(dto)
+                    .build();
+
+            elasticsearchClient.index(indexRequest);
+        }
+    }
+
+    public List<AutocompleteResult> getDrugSearch(String input, String field,
+                                                  int pageSize, int page) throws IOException {
+        List<AutocompleteResult> result = new ArrayList<>();
+
+        List<DrugDTO> drugs = getMatchingDrugsFromElasticsearch(input, field, pageSize, page);
+        for (DrugDTO drug : drugs) {
+            String drugId = String.valueOf(drug.id());
+            String drugName = redisService.getDrugNameFromCache(drugId);
+            String manufacturer = redisService.getManufacturerFromCache(drugId);
+            String imageUrl = redisService.getImageUrlFromCache(drugId);
+
+            result.add(new AutocompleteResult(
+                    drug.id(),
+                    drugName != null ? drugName : drug.drugName(),
+                    manufacturer != null? manufacturer : drug.manufacturer(),
+                    imageUrl != null ? imageUrl : drug.imageUrl()
+            ));
+        }
+        return result;
+    }
+
+    private List<DrugDTO> getMatchingDrugsFromElasticsearch(String input, String field,
+                                                            int pageSize, int page) throws IOException {
+        int from = page * pageSize;
+
+        SearchResponse<DrugDTO> response = elasticsearchClient.search(s -> s
+                .index(index)
+                .from(from)
+                .size(pageSize)
+                        .query(q -> q
+                                .bool(b -> b
+                                        .minimumShouldMatch("1")
+                                        .should(sh -> sh.prefix(p -> p
+                                                .field(field + ".edge")
+                                                .value(input)
+                                                .boost(90.0f)
+                                        )).should(sh -> sh.match(p -> p
+                                                .field(field + ".gram")
+                                                .query(input)
+                                                .boost(5.0f)
+                                        ))
+                                        .should(sh -> sh.fuzzy(f -> f
+                                                .field(field)
+                                                .value(input)
+                                                .fuzziness("AUTO")
+                                                .boost(1.0f)
+                                        ))
+                                )
+                        )
+                , DrugDTO.class
+
+        );
+
+        return response.hits().hits().stream()
+                .map(Hit::source)
+                .filter(Objects::nonNull)
+                .toList();
+    }
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Service/DataSyncService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Service/DataSyncService.java
@@ -1,0 +1,53 @@
+package com.oauth2.AutoComplete.Service;
+
+import com.oauth2.Drug.Domain.Drug;
+import com.oauth2.Drug.Domain.Ingredient;
+import com.oauth2.Drug.Repository.DrugRepository;
+import com.oauth2.Drug.Repository.IngredientRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class DataSyncService {
+
+    private final RedisService redisService;
+
+    private final DrugRepository drugRepository;
+
+    private final IngredientRepository ingredientRepository;
+
+    @Value("${redis.drug.drug}")
+    private String hashDrug;
+    @Value("${redis.drug.manufacturer}")
+    private String hashMaufacturer;
+    @Value("${redis.drug.image}")
+    private String hashImage;
+
+    public DataSyncService(RedisService redisService, DrugRepository drugRepository, IngredientRepository ingredientRepository) {
+        this.redisService = redisService;
+        this.drugRepository = drugRepository;
+        this.ingredientRepository = ingredientRepository;
+    }
+
+    //@PostConstruct // redis 캐시 설정
+    public void syncDataWithRedis() {
+        List<Drug> drugs = drugRepository.findAll();
+        List<Ingredient> ingredients = ingredientRepository.findAll();
+        for (Drug drug : drugs) {
+            String drugId = String.valueOf(drug.getId());
+            redisService.addAutocompleteSuggestion(drugId, hashDrug,drug.getName());
+            redisService.addAutocompleteSuggestion(drugId, hashMaufacturer, drug.getManufacturer());
+            //redisService.addAutocompleteSuggestion(drugId, hashImage, null); // 추후에 이미지 삽입 방법 결정 시 추가
+        }
+
+        /*
+        for(Ingredient ingredient : ingredients){
+            String ingredientId = ingredient.getId();
+            redisService.addAutocompleteSuggestion(ingredientId, "ingredient", ingredient.getNameKr());
+        }
+        */
+    }
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Service/DrugDetailService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Service/DrugDetailService.java
@@ -1,0 +1,22 @@
+package com.oauth2.AutoComplete.Service;
+
+import com.oauth2.DetailPage.Dto.DrugDetail;
+import com.oauth2.DetailPage.Mapper.DrugDetailRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DrugDetailService {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public DrugDetailService(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    public DrugDetail getDrugDetailById(int drugId) {
+        String query = "SELECT * FROM drug WHERE id = ?";
+        return jdbcTemplate.queryForObject(query, new Object[]{drugId}, new DrugDetailRowMapper());
+    }
+}
+

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Service/RedisService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/AutoComplete/Service/RedisService.java
@@ -1,0 +1,41 @@
+package com.oauth2.AutoComplete.Service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RedisService {
+
+    private final StringRedisTemplate redisTemplate;
+
+    @Value("${redis.index}")
+    private String key;
+
+    @Value("${redis.drug.drug}")
+    private String hashDrug;
+    @Value("${redis.drug.manufacturer}")
+    private String hashMaufacturer;
+    @Value("${redis.drug.image}")
+    private String hashImage;
+
+    public RedisService(StringRedisTemplate redisTemplate) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void addAutocompleteSuggestion(String drugId, String column, String input) {
+        redisTemplate.opsForHash().put(key + drugId, column, input);
+    }
+
+    public String getDrugNameFromCache(String drugId) {
+        return (String) redisTemplate.opsForHash().get(key + drugId, hashDrug);
+    }
+
+    public String getManufacturerFromCache(String drugId) {
+        return (String) redisTemplate.opsForHash().get(key + drugId, hashMaufacturer);
+    }
+
+    public String getImageUrlFromCache(String drugId) {
+        return (String) redisTemplate.opsForHash().get(key + drugId, hashImage);
+    }
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/DetailPage/Dto/DrugDetail.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/DetailPage/Dto/DrugDetail.java
@@ -1,0 +1,31 @@
+package com.oauth2.DetailPage.Dto;
+
+import com.oauth2.Drug.Domain.Drug;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Date;
+import java.util.List;
+
+@Getter
+@Setter
+public class DrugDetail {
+    private Long id;
+    private String name;
+    private String manufacturer;
+
+    private List<String> ingredients;
+
+    private String form;
+    private List<String> packaging;
+
+    private String atcCode;
+
+    private Drug.Tag tag;
+
+    private Date approvalDate;
+
+    private List<StorageDetail> storageDetails;
+    private List<EffectDetail> effectDetails;
+
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/DetailPage/Dto/EffectDetail.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/DetailPage/Dto/EffectDetail.java
@@ -1,0 +1,14 @@
+package com.oauth2.DetailPage.Dto;
+
+
+import com.oauth2.Drug.Domain.DrugEffect;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class EffectDetail {
+    private DrugEffect.Type Type;
+
+    private String effect;
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/DetailPage/Dto/StorageDetail.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/DetailPage/Dto/StorageDetail.java
@@ -1,0 +1,13 @@
+package com.oauth2.DetailPage.Dto;
+
+import com.oauth2.Drug.Domain.DrugStorageCondition;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class StorageDetail {
+    private DrugStorageCondition.Category category;
+    private String description;
+    private String iconUrl;
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/DetailPage/Mapper/DrugDetailRowMapper.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/DetailPage/Mapper/DrugDetailRowMapper.java
@@ -1,0 +1,27 @@
+package com.oauth2.DetailPage.Mapper;
+
+import com.oauth2.DetailPage.Dto.DrugDetail;
+import org.springframework.jdbc.core.RowMapper;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+public class DrugDetailRowMapper implements RowMapper<DrugDetail> {
+
+    public DrugDetail mapRow(ResultSet rs, int rowNum) throws SQLException {
+        DrugDetail drugDetail = new DrugDetail();
+        drugDetail.setId(rs.getLong("id"));
+        drugDetail.setName(rs.getString("drug_name"));
+        drugDetail.setManufacturer(rs.getString("manufacturer"));
+
+        // 성분을 리스트로 변환
+        String ingredientsString = rs.getString("ingredients");
+        if (ingredientsString != null && !ingredientsString.isEmpty()) {
+            List<String> ingredients = Arrays.asList(ingredientsString.split(","));
+            drugDetail.setIngredients(ingredients);
+        }
+
+        return drugDetail;
+    }
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/Drug.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/Drug.java
@@ -1,0 +1,36 @@
+package com.oauth2.Drug.Domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import java.util.Date;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "drugs")
+public class Drug {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @Column(nullable = false)
+    private String name;
+    private String code;
+    private String manufacturer;
+    private Date approvalDate;
+
+    @Column(columnDefinition = "TEXT")
+    private String packaging;
+
+    private String form;
+    private String atcCode;
+
+    @Enumerated(EnumType.STRING)
+    private Tag tag;
+
+    public enum Tag {
+        EXPERT, COMMON
+    }
+
+    // getter, setter 생략
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/DrugCaution.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/DrugCaution.java
@@ -1,0 +1,35 @@
+package com.oauth2.Drug.Domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "drug_cautions")
+public class DrugCaution {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long cautionId;
+
+    private Long ingredientId;
+
+    @Enumerated(EnumType.STRING)
+    private ConditionType conditionType;
+    private String conditionValue;
+
+    @Enumerated(EnumType.STRING)
+    private Level level;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    public enum ConditionType {
+        GENDER, PREGNANCY, AGE, CONDITION
+    }
+    public enum Level {
+        CAUTION, TABOO
+    }
+    // getter, setter 생략
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/DrugEffect.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/DrugEffect.java
@@ -1,0 +1,28 @@
+package com.oauth2.Drug.Domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "drug_effects")
+public class DrugEffect {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long drugId;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    @Column(columnDefinition = "LONGTEXT")
+    private String content;
+
+    public enum Type {
+        EFFECT, USAGE, CAUTION
+    }
+    // getter, setter 생략
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/DrugIngredient.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/DrugIngredient.java
@@ -1,0 +1,28 @@
+package com.oauth2.Drug.Domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "drug_ingredients")
+public class DrugIngredient {
+    @EmbeddedId
+    private DrugIngredientId id;
+
+    private Float amount;
+    private String unit;
+
+    // getter, setter 생략
+
+    @Getter
+    @Setter
+    @Embeddable
+    public static class DrugIngredientId implements java.io.Serializable {
+        private Long drugId;
+        private Long ingredientId;
+        // equals, hashCode 생략
+    }
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/DrugInteraction.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/DrugInteraction.java
@@ -1,0 +1,29 @@
+package com.oauth2.Drug.Domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "drug_interactions")
+public class DrugInteraction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long interactionId;
+
+    private Long ingredientId1;
+    private Long ingredientId2;
+
+    @Enumerated(EnumType.STRING)
+    private InteractionLevel interactionLevel;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    public enum InteractionLevel {
+        CAUTION, TABOO, INFO
+    }
+    // getter, setter 생략
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/DrugStorageCondition.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/DrugStorageCondition.java
@@ -1,0 +1,27 @@
+package com.oauth2.Drug.Domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "drug_storage_conditions")
+public class DrugStorageCondition {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long drugId;
+
+    @Enumerated(EnumType.STRING)
+    private Category category;
+    private String value;
+    private String iconUrl;
+
+    public enum Category {
+        TEMPERATURE, CONTAINER, HUMID, LIGHT, PLACE
+    }
+    // getter, setter 생략
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/Ingredient.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Domain/Ingredient.java
@@ -1,0 +1,20 @@
+package com.oauth2.Drug.Domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "ingredients")
+public class Ingredient {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String nameKr;
+    private String nameEn;
+
+    // getter, setter 생략
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/DrugImport/Controller/DrugImportController.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/DrugImport/Controller/DrugImportController.java
@@ -1,0 +1,23 @@
+package com.oauth2.Drug.DrugImport.Controller;
+
+import com.oauth2.Drug.DrugImport.Service.DrugImportService;
+import org.springframework.web.bind.annotation.*;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+
+@RestController
+public class DrugImportController {
+    private final DrugImportService drugImportService;
+
+    public DrugImportController(DrugImportService drugImportService) {
+        this.drugImportService = drugImportService;
+    }
+
+    @PostMapping("/api/import")
+    public String importDrugs(@RequestParam String url) {
+        // URL 디코딩
+        String decodedPath = URLDecoder.decode(url, StandardCharsets.UTF_8);
+        drugImportService.importFromFile(decodedPath);
+        return "import success";
+    }
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/DrugImport/Service/DrugImportService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/DrugImport/Service/DrugImportService.java
@@ -1,0 +1,294 @@
+package com.oauth2.Drug.DrugImport.Service;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.oauth2.Drug.Domain.*;
+import com.oauth2.Drug.Service.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class DrugImportService {
+    private final DrugService drugService;
+    private final IngredientService ingredientService;
+    private final DrugIngredientService drugIngredientService;
+    private final DrugEffectService drugEffectService;
+    private final DrugStorageConditionService drugStorageConditionService;
+
+    // TODO: 나머지 서비스도 필요시 주입
+
+    public DrugImportService(DrugService drugService, IngredientService ingredientService, DrugIngredientService drugIngredientService, DrugEffectService drugEffectService, DrugStorageConditionService drugStorageConditionService) {
+        this.drugService = drugService;
+        this.ingredientService = ingredientService;
+        this.drugIngredientService = drugIngredientService;
+        this.drugEffectService = drugEffectService;
+        this.drugStorageConditionService = drugStorageConditionService;
+    }
+
+    public void importFromFile(String filePath) {
+        try {
+            String content = Files.readString(Paths.get(filePath));
+            String[] drugBlocks = content.split("={60,}"); // 60개 이상 =
+            for (String block : drugBlocks) {
+                if (block.trim().isEmpty()) continue;
+                try {
+                    importSingleDrug(block);
+                } catch (Exception e) {
+                    System.out.println("약 데이터 저장 실패: " + e.getMessage());
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Transactional
+    public void importSingleDrug(String block) {
+        // 1. 기본 정보 파싱
+        String[] lines = block.split("\n");
+        String name = null, code = null, manufacturer = null, approvalDate = null, packaging = null, form = null, atcCode = null, tag = null;
+        String ingredientLine = null;
+        StringBuilder effect = new StringBuilder();
+        StringBuilder usage = new StringBuilder();
+        StringBuilder caution = new StringBuilder();
+        String section = "";
+        for (String line : lines) {
+            line = line.trim();
+            if (line.contains("제품명:")) name = line.split("제품명:", 2)[1].trim();
+            else if (line.contains("품목일련번호:")) code = line.split("품목일련번호:", 2)[1].trim();
+            else if (line.contains("제조사:")) manufacturer = line.split("제조사:", 2)[1].trim();
+            else if (line.contains("허가일자:")) approvalDate = line.split("허가일자:", 2)[1].trim();
+            else if (line.contains("포장단위:")) packaging = line.split("포장단위:", 2)[1].trim();
+            else if (line.contains("제형:")) form = line.split("제형:", 2)[1].trim();
+            else if (line.contains("ATC 코드:")) atcCode = line.split("ATC 코드:", 2)[1].trim();
+            else if (line.contains("의약품 분류:")) tag = line.split("의약품 분류:", 2)[1].trim();
+            else if (line.contains("약품 성분 및 용량:")) ingredientLine = line.split("약품 성분 및 용량:", 2)[1].trim();
+            else if (line.startsWith("[효능효과]")) section = "effect";
+            else if (line.startsWith("[용법용량]")) section = "usage";
+            else if (line.startsWith("[사용상의주의사항]")) section = "caution";
+            else if (line.startsWith("[")) section = "";
+            else {
+                switch (section) {
+                    case "effect" -> effect.append(line).append("\n");
+                    case "usage" -> usage.append(line).append("\n");
+                    case "caution" -> caution.append(line).append("\n");
+                }
+            }
+        }
+        // name이 없으면 Drug 저장 건너뜀
+        if (name == null || name.isEmpty()) {
+            System.out.println("제품명 누락 블록 건너뜀: " + block);
+            return;
+        }
+        // 이미 존재하는 약이면 스킵
+        //if(drugRepository.findByName(name).isPresent()) return;
+
+        // 2. Drug 저장 (제품명 기준 중복 체크)
+        Optional<Drug> drugOpt = drugService.findByName(name);
+        Drug drug;
+        if (drugOpt.isPresent()) {
+            drug = drugOpt.get();
+        } else {
+            drug = new Drug();
+            drug.setName(name);
+            drug.setCode(code);
+            drug.setManufacturer(manufacturer);
+            drug.setPackaging(packaging);
+            drug.setForm(form);
+            drug.setAtcCode(atcCode);
+            // approvalDate 파싱 및 세팅
+            if (approvalDate != null && approvalDate.matches("\\d{8}")) {
+                try {
+                    LocalDate localDate = LocalDate.parse(approvalDate, DateTimeFormatter.ofPattern("yyyyMMdd"));
+                    drug.setApprovalDate(Date.valueOf(localDate));
+                } catch (Exception e) {
+                    System.out.println("허가일자 파싱 오류: " + approvalDate);
+                }
+            }
+            if (tag != null) drug.setTag(tag.equals("일반의약품")? Drug.Tag.COMMON: Drug.Tag.EXPERT);
+            drug = drugService.save(drug);
+        }
+        // 3. 성분 파싱 및 저장
+        if (ingredientLine != null && !ingredientLine.isEmpty()) {
+            String[] ingredients = ingredientLine.split(";");
+            for (String ing : ingredients) {
+                String[] parts = ing.split("\\|");
+                String nameKr = null, amount = null, unit = null;
+                for (String part : parts) {
+                    part = part.trim();
+                    if (part.startsWith("성분명 :")) nameKr = part.replace("성분명 :", "").trim();
+                    else if (part.startsWith("분량 :")) amount = part.replace("분량 :", "").trim();
+                    else if (part.startsWith("단위 :")) unit = part.replace("단위 :", "").trim();
+                }
+                if (nameKr == null) continue;
+                Optional<Ingredient> ingOpt = ingredientService.findByNameKr(nameKr);
+                Ingredient ingredient;
+                if (ingOpt.isPresent()) {
+                    ingredient = ingOpt.get();
+                } else {
+                    ingredient = new Ingredient();
+                    ingredient.setNameKr(nameKr);
+                    ingredient = ingredientService.save(ingredient);
+                }
+                // DrugIngredient 매핑 저장
+                DrugIngredient di = new DrugIngredient();
+                DrugIngredient.DrugIngredientId diId = new DrugIngredient.DrugIngredientId();
+                diId.setDrugId(drug.getId());
+                diId.setIngredientId(ingredient.getId());
+                di.setId(diId);
+                if (amount != null && !amount.isEmpty()) {
+                    try {
+                        di.setAmount(Float.parseFloat(amount));
+                    } catch (NumberFormatException e) {
+                        System.out.println("성분 분량 파싱 오류: " + amount + " (" + nameKr + ")");
+                        // 오류시 분량은 저장하지 않음
+                    }
+                }
+                di.setUnit(unit);
+                drugIngredientService.save(di);
+            }
+        }
+        // 4. DrugEffect 저장 (표 등 긴 데이터 방지)
+        String filteredEffect = filterContent(effect.toString());
+        String filteredUsage = filterContent(usage.toString());
+        String filteredCaution = filterContent(caution.toString());
+        if (filteredEffect.length() > 0) {
+            DrugEffect de = new DrugEffect();
+            de.setDrugId(drug.getId());
+            de.setType(DrugEffect.Type.EFFECT);
+            de.setContent(filteredEffect.trim());
+            drugEffectService.save(de);
+        }
+        if (filteredUsage.length() > 0) {
+            DrugEffect de = new DrugEffect();
+            de.setDrugId(drug.getId());
+            de.setType(DrugEffect.Type.USAGE);
+            de.setContent(filteredUsage.trim());
+            drugEffectService.save(de);
+        }
+        if (filteredCaution.length() > 0) {
+            DrugEffect de = new DrugEffect();
+            de.setDrugId(drug.getId());
+            de.setType(DrugEffect.Type.CAUTION);
+            de.setContent(filteredCaution.trim());
+            drugEffectService.save(de);
+        }
+        // 5. 보관 방법 파싱 및 저장
+        if (filteredCaution.length() > 0) {
+            // 개행 문자 처리 로직 개선
+            String[] cautionLines = filteredCaution.split("\\r?\\n");
+            for (String cautionLine : cautionLines) {
+                String line = cautionLine.trim();
+
+                // 보관 관련 키워드 포함 여부 검사
+                if (line.contains("닿지 않는 곳에 보관")) continue;
+                if (!line.contains("보관") || !line.contains("바꾸어 넣지")) continue;
+                // 긍정/부정 연결어 패턴
+                String regex = "(보관하지 (않고|않으며|않게|않을 것|말 것|않는다|않도록|말고)?|보관하면 안된다|보관하지 말고|(보관(하며|하고|하도록|한다|할 것)?))";
+                Pattern pattern = Pattern.compile(regex);
+                Matcher matcher = pattern.matcher(line);
+                int lastPos = 0;
+                boolean lastNegative = false; // 기본값
+                while (matcher.find()) {
+                    String part = line.substring(lastPos, matcher.start());
+                    boolean isNegative = matcher.group().contains("보관하지") || matcher.group().contains("보관하면 안된다") || lastNegative;
+                    // 키워드별 저장
+                    makeStoreRule(drug, part, isNegative);
+                    lastPos = matcher.end();
+                    String matched = matcher.group();
+                    lastNegative = matched.startsWith("보관하지") || matched.startsWith("보관하면 안된다");
+                }
+            }
+        }
+    }
+
+    private void makeStoreRule(Drug drug, String part, boolean isNegative) {
+        // 보관 용기 파싱
+        if (part.contains("밀폐용기") || part.contains("밀페하여")) {
+            saveStorageCondition("밀폐용기",drug, DrugStorageCondition.Category.CONTAINER,isNegative);
+        }
+        if (part.contains("바꾸어 넣지") || part.contains("원래의 용기")) {
+            saveStorageCondition("용기변화x",drug, DrugStorageCondition.Category.CONTAINER,isNegative);
+        }
+
+        // 보관 장소 파싱
+        if (part.contains("밀폐된 장소")) {
+            saveStorageCondition("밀폐된 장소",drug, DrugStorageCondition.Category.PLACE,isNegative);
+        }
+        if (part.contains("서늘한 곳")) {
+            saveStorageCondition("서늘한 곳",drug, DrugStorageCondition.Category.PLACE,isNegative);
+        }
+
+        // 온도 파싱
+        Matcher m = Pattern.compile("(\\d+)+℃").matcher(part);
+        while (m.find()) {
+            String tempStr = m.group(1);
+            int temp = Integer.parseInt(tempStr);
+            String tempType = (temp >= 40) ? "고온" : (temp <= 10 ? "저온" : "실온");
+            saveStorageCondition(tempType,drug, DrugStorageCondition.Category.TEMPERATURE,isNegative);
+        }
+        if (part.contains("고온")) {
+            saveStorageCondition("고온",drug, DrugStorageCondition.Category.TEMPERATURE,isNegative);
+        }
+        if (part.contains("실온")) {
+            saveStorageCondition("실온",drug, DrugStorageCondition.Category.TEMPERATURE,isNegative);
+        }
+        if (part.contains("저온")) {
+            saveStorageCondition("저온",drug, DrugStorageCondition.Category.TEMPERATURE,isNegative);
+        }
+        if (part.contains("냉장")) {
+            saveStorageCondition("냉장",drug, DrugStorageCondition.Category.TEMPERATURE,isNegative);
+        }
+        if (part.contains("냉동")) {
+            saveStorageCondition("냉동",drug, DrugStorageCondition.Category.TEMPERATURE,isNegative);
+        }
+        if (part.contains("얼리지")) {
+            saveStorageCondition("냉동x",drug, DrugStorageCondition.Category.TEMPERATURE,isNegative);
+        }
+
+        // 습도 파싱
+        if (part.contains("건조")) {
+            saveStorageCondition("건조",drug, DrugStorageCondition.Category.HUMID,isNegative);
+        }
+        if (part.contains("습기가 적은")) {
+            saveStorageCondition("습기가 적은",drug, DrugStorageCondition.Category.HUMID,isNegative);
+        }
+
+        // 직사광선
+        if (((part.contains("직사광선") || part.contains("직사일광")) && part.contains("피하여")) || part.contains("차광")) {
+            saveStorageCondition("직사광선x",drug, DrugStorageCondition.Category.LIGHT,isNegative);
+        }
+    }
+
+    private void saveStorageCondition(String q, Drug drug,
+                                      DrugStorageCondition.Category category, boolean isNegative){
+        DrugStorageCondition cond = new DrugStorageCondition();
+        cond.setDrugId(drug.getId());
+        cond.setCategory(category);
+        cond.setValue(isNegative ? q+"x" : q);
+        drugStorageConditionService.save(cond);
+    }
+
+    private String filterContent(String content) {
+        String[] lines = content.split("\\n");
+        StringBuilder sb = new StringBuilder();
+        int emptyCount = 0;
+        for (String line : lines) {
+            if (line.trim().isEmpty()) {
+                emptyCount++;
+                if (emptyCount == 2) break;
+            } else {
+                emptyCount = 0;
+            }
+            sb.append(line).append("\n");
+        }
+        return sb.toString();
+    }
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugCautionRepository.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugCautionRepository.java
@@ -1,0 +1,8 @@
+package com.oauth2.Drug.Repository;
+
+
+import com.oauth2.Drug.Domain.DrugCaution;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DrugCautionRepository extends JpaRepository<DrugCaution, Long> {
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugEffectRepository.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugEffectRepository.java
@@ -1,0 +1,8 @@
+package com.oauth2.Drug.Repository;
+
+
+import com.oauth2.Drug.Domain.DrugEffect;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DrugEffectRepository extends JpaRepository<DrugEffect, Long> {
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugIngredientRepository.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugIngredientRepository.java
@@ -1,0 +1,10 @@
+package com.oauth2.Drug.Repository;
+
+import com.oauth2.Drug.Domain.DrugIngredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface DrugIngredientRepository extends JpaRepository<DrugIngredient, DrugIngredient.DrugIngredientId> {
+    List<DrugIngredient> findById_IngredientId(Long ingredientId);
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugInteractionRepository.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugInteractionRepository.java
@@ -1,0 +1,7 @@
+package com.oauth2.Drug.Repository;
+
+import com.oauth2.Drug.Domain.DrugInteraction;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DrugInteractionRepository extends JpaRepository<DrugInteraction, Long> {
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugRepository.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugRepository.java
@@ -1,0 +1,13 @@
+package com.oauth2.Drug.Repository;
+
+
+import com.oauth2.Drug.Domain.Drug;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DrugRepository extends JpaRepository<Drug, Long> {
+    Optional<Drug> findByName(String name);
+    List<Drug> findByIdIn(List<Long> ids);
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugStorageConditionRepository.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/DrugStorageConditionRepository.java
@@ -1,0 +1,7 @@
+package com.oauth2.Drug.Repository;
+
+import com.oauth2.Drug.Domain.DrugStorageCondition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DrugStorageConditionRepository extends JpaRepository<DrugStorageCondition, Long> {
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/IngredientRepository.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Repository/IngredientRepository.java
@@ -1,0 +1,10 @@
+package com.oauth2.Drug.Repository;
+
+import com.oauth2.Drug.Domain.Ingredient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface IngredientRepository extends JpaRepository<Ingredient, Long> {
+    Optional<Ingredient> findByNameKr(String nameKr);
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugCautionService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugCautionService.java
@@ -1,0 +1,28 @@
+package com.oauth2.Drug.Service;
+
+import com.oauth2.Drug.Domain.DrugCaution;
+import com.oauth2.Drug.Repository.DrugCautionRepository;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+public class DrugCautionService {
+    private final DrugCautionRepository drugCautionRepository;
+
+    public DrugCautionService(DrugCautionRepository drugCautionRepository) {
+        this.drugCautionRepository = drugCautionRepository;
+    }
+
+    public List<DrugCaution> findAll() {
+        return drugCautionRepository.findAll();
+    }
+    public DrugCaution save(DrugCaution drugCaution) {
+        return drugCautionRepository.save(drugCaution);
+    }
+    public void delete(Long id) {
+        drugCautionRepository.deleteById(id);
+    }
+    public DrugCaution findById(Long id) {
+        return drugCautionRepository.findById(id).orElse(null);
+    }
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugEffectService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugEffectService.java
@@ -1,0 +1,22 @@
+package com.oauth2.Drug.Service;
+
+import com.oauth2.Drug.Domain.DrugEffect;
+import com.oauth2.Drug.Repository.DrugEffectRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DrugEffectService {
+    private final DrugEffectRepository drugEffectRepository;
+
+    public DrugEffectService(DrugEffectRepository drugEffectRepository) {
+        this.drugEffectRepository = drugEffectRepository;
+    }
+
+    public DrugEffect findById(Long id) {
+        return drugEffectRepository.findById(id).orElse(null);
+    }
+
+    public DrugEffect save(DrugEffect drugEffect) {
+        return drugEffectRepository.save(drugEffect);
+    }
+}

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugIngredientService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugIngredientService.java
@@ -1,0 +1,28 @@
+package com.oauth2.Drug.Service;
+
+import com.oauth2.Drug.Domain.DrugIngredient;
+import com.oauth2.Drug.Repository.DrugIngredientRepository;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+public class DrugIngredientService {
+    private final DrugIngredientRepository drugIngredientRepository;
+
+    public DrugIngredientService(DrugIngredientRepository drugIngredientRepository) {
+        this.drugIngredientRepository = drugIngredientRepository;
+    }
+
+    public List<DrugIngredient> findAll() {
+        return drugIngredientRepository.findAll();
+    }
+    public DrugIngredient save(DrugIngredient drugIngredient) {
+        return drugIngredientRepository.save(drugIngredient);
+    }
+    public void delete(DrugIngredient.DrugIngredientId id) {
+        drugIngredientRepository.deleteById(id);
+    }
+    public DrugIngredient findById(DrugIngredient.DrugIngredientId id) {
+        return drugIngredientRepository.findById(id).orElse(null);
+    }
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugInteractionService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugInteractionService.java
@@ -1,0 +1,28 @@
+package com.oauth2.Drug.Service;
+
+import com.oauth2.Drug.Domain.DrugInteraction;
+import com.oauth2.Drug.Repository.DrugInteractionRepository;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+public class DrugInteractionService {
+    private final DrugInteractionRepository drugInteractionRepository;
+
+    public DrugInteractionService(DrugInteractionRepository drugInteractionRepository) {
+        this.drugInteractionRepository = drugInteractionRepository;
+    }
+
+    public List<DrugInteraction> findAll() {
+        return drugInteractionRepository.findAll();
+    }
+    public DrugInteraction save(DrugInteraction drugInteraction) {
+        return drugInteractionRepository.save(drugInteraction);
+    }
+    public void delete(Long id) {
+        drugInteractionRepository.deleteById(id);
+    }
+    public DrugInteraction findById(Long id) {
+        return drugInteractionRepository.findById(id).orElse(null);
+    }
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugService.java
@@ -1,0 +1,50 @@
+package com.oauth2.Drug.Service;
+
+import com.oauth2.Drug.Domain.Drug;
+import com.oauth2.Drug.Domain.DrugIngredient;
+import com.oauth2.Drug.Domain.Ingredient;
+import com.oauth2.Drug.Repository.DrugIngredientRepository;
+import com.oauth2.Drug.Repository.DrugRepository;
+import com.oauth2.Drug.Repository.IngredientRepository;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class DrugService {
+    private final DrugRepository drugRepository;
+    private final IngredientRepository ingredientRepository;
+    private final DrugIngredientRepository drugIngredientRepository;
+
+    public DrugService(DrugRepository drugRepository, IngredientRepository ingredientRepository, DrugIngredientRepository drugIngredientRepository) {
+        this.drugRepository = drugRepository;
+        this.ingredientRepository = ingredientRepository;
+        this.drugIngredientRepository = drugIngredientRepository;
+    }
+
+    public List<Drug> findAll() {
+        return drugRepository.findAll();
+    }
+    public Drug save(Drug drug) {
+        return drugRepository.save(drug);
+    }
+    public void delete(Long id) {
+        drugRepository.deleteById(id);
+    }
+    public Drug findById(Long id) {
+        return drugRepository.findById(id).orElse(null);
+    }
+    public Optional<Drug> findByName(String name) {
+        return drugRepository.findByName(name);
+    }
+    public List<Drug> getDrugsByIngredientName(String ingredientName) {
+        Ingredient ingredient = ingredientRepository.findByNameKr(ingredientName)
+            .orElseThrow(() -> new RuntimeException("해당 성분이 존재하지 않습니다."));
+        List<DrugIngredient> drugIngredients = drugIngredientRepository.findById_IngredientId(ingredient.getId());
+        List<Long> drugIds = drugIngredients.stream()
+            .map(di -> di.getId().getDrugId())
+            .toList();
+        if (drugIds.isEmpty()) return List.of();
+        return drugRepository.findByIdIn(drugIds);
+    }
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugStorageConditionService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/DrugStorageConditionService.java
@@ -1,0 +1,28 @@
+package com.oauth2.Drug.Service;
+
+import com.oauth2.Drug.Domain.DrugStorageCondition;
+import com.oauth2.Drug.Repository.DrugStorageConditionRepository;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+public class DrugStorageConditionService {
+    private final DrugStorageConditionRepository drugStorageConditionRepository;
+
+    public DrugStorageConditionService(DrugStorageConditionRepository drugStorageConditionRepository) {
+        this.drugStorageConditionRepository = drugStorageConditionRepository;
+    }
+
+    public List<DrugStorageCondition> findAll() {
+        return drugStorageConditionRepository.findAll();
+    }
+    public DrugStorageCondition save(DrugStorageCondition drugStorageCondition) {
+        return drugStorageConditionRepository.save(drugStorageCondition);
+    }
+    public void delete(Long id) {
+        drugStorageConditionRepository.deleteById(id);
+    }
+    public DrugStorageCondition findById(Long id) {
+        return drugStorageConditionRepository.findById(id).orElse(null);
+    }
+} 

--- a/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/IngredientService.java
+++ b/PillTip/BE/test_oauth2/src/main/java/com/oauth2/Drug/Service/IngredientService.java
@@ -1,0 +1,32 @@
+package com.oauth2.Drug.Service;
+
+import com.oauth2.Drug.Domain.Ingredient;
+import com.oauth2.Drug.Repository.IngredientRepository;
+import org.springframework.stereotype.Service;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class IngredientService {
+    private final IngredientRepository ingredientRepository;
+
+    public IngredientService(IngredientRepository ingredientRepository) {
+        this.ingredientRepository = ingredientRepository;
+    }
+
+    public List<Ingredient> findAll() {
+        return ingredientRepository.findAll();
+    }
+    public Ingredient save(Ingredient ingredient) {
+        return ingredientRepository.save(ingredient);
+    }
+    public void delete(Long id) {
+        ingredientRepository.deleteById(id);
+    }
+    public Ingredient findById(Long id) {
+        return ingredientRepository.findById(id).orElse(null);
+    }
+    public Optional<Ingredient> findByNameKr(String nameKr) {
+        return ingredientRepository.findByNameKr(nameKr);
+    }
+} 


### PR DESCRIPTION
- issue num : [FEAT] 자동완성 기능 초기 구현 #36

- elastic search API와 redis를 활용한 자동완성 기능의 초기 단계입니다.
- elastic API의 index에 우리가 검색할 데이터 인덱스를, redis에 검색 결과를 통해 매핑할 데이터를 삽입합니다.
- EdgeNgram을 사용하여 prefix를 커버하고, NGram을 통해 단어 중간에 단어가 나오는 경우도 커버하도록 했습니다.
- 지금은 약 이름만 페이지 크기를 수정하면 자동완성에 바로 사용할 수 있을 것 같습니다.
- 제조사, 성분명은 의약품과는 다른 로직을 가지므로, 새로운 인덱스를 만들 필요가 있을 것 같습니다.

- 지금까지 만든건 사용자가 불완전한 입력을 한 뒤, 검색을 눌렀을 때, 검색결과로 표출될 약들을 표출해준다는 느낌에 더 가까움
- 고로, 위에서 말한 바와 같이 새로운 인덱스를 만들어 새로운 매핑구조를 형성하고 api를 구현하여야 다른 요소에 대해서도 정상 작동할 것으로 기대됨 